### PR TITLE
Remove peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   },
   "dependencies": {
     "humps": "^2.0.1",
-    "query-string": "^6.4.0"
+    "query-string": "^6.4.0",
+    "react": "^16.8.5",
+    "react-dom": "^16.8.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -53,12 +55,6 @@
     "flow-typed": "^2.5.1",
     "husky": "^1.3.1",
     "jest": "^24.5.0",
-    "react": "^16.8.5",
-    "react-dom": "^16.8.5",
     "react-testing-library": "^6.0.3"
-  },
-  "peerDependencies": {
-    "react": "^16.8.5",
-    "react-dom": "^16.8.5"
   }
 }


### PR DESCRIPTION
Removing peer dependencies to fix this warning:
```
warning " > react-smart-payment-buttons@0.2.2" has incorrect peer dependency "react@^16.8.5".
warning " > react-smart-payment-buttons@0.2.2" has incorrect peer dependency "react-dom@^16.8.5".
```